### PR TITLE
feat: add header component

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,6 @@
 import './App.css'
 import { Grommet } from 'grommet'
+import Main from './components/Main'
 
 const theme = {
  global: {
@@ -12,7 +13,7 @@ const theme = {
 function App() {
  return (
   <Grommet theme={theme}>
-   <p>ANZSIC Fairy</p>
+   <Main />
   </Grommet>
  )
 }

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,0 +1,9 @@
+function Header() {
+ return (
+  <div>
+   <p>Header</p>
+  </div>
+ )
+}
+
+export default Header

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,9 +1,9 @@
-import Header from './Header'
+import MainHeader from './MainHeader'
 
 function Main() {
  return (
   <div>
-   <Header />
+   <MainHeader />
   </div>
  )
 }

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,7 +1,9 @@
+import Header from './Header'
+
 function Main() {
  return (
   <div>
-   <p>Main</p>
+   <Header />
   </div>
  )
 }

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,0 +1,9 @@
+function Main() {
+ return (
+  <div>
+   <p>Main</p>
+  </div>
+ )
+}
+
+export default Main

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -1,4 +1,4 @@
-function Header() {
+function MainHeader() {
  return (
   <div>
    <p>Header</p>
@@ -6,4 +6,4 @@ function Header() {
  )
 }
 
-export default Header
+export default MainHeader

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -1,8 +1,10 @@
+import { Header, Heading } from 'grommet'
+
 function MainHeader() {
  return (
-  <div>
-   <p>Header</p>
-  </div>
+  <Header background='brand' height='xsmall' pad='medium'>
+   <Heading size='small'>&#129498; ANZSIC Fairy</Heading>
+  </Header>
  )
 }
 

--- a/src/components/MainHeader.js
+++ b/src/components/MainHeader.js
@@ -2,7 +2,7 @@ import { Header, Heading } from 'grommet'
 
 function MainHeader() {
  return (
-  <Header background='brand' height='xsmall' pad='medium'>
+  <Header background='brand' direction='column'>
    <Heading size='small'>&#129498; ANZSIC Fairy</Heading>
   </Header>
  )


### PR DESCRIPTION
**:sparkles: Description**
Add simple header component 

**:dizzy: Changes**
- Add `Main` component to manage layout of app (the `App` component to be used for Grommet theming)
- Add heading and header box to `MainHeader` component